### PR TITLE
reduce opacity on comparator series, to allow the eye to separate them

### DIFF
--- a/src/components/Chart.js
+++ b/src/components/Chart.js
@@ -175,7 +175,8 @@ function Chart(props) {
                           data: {
                             fill: colorScale[
                               seriesNames.indexOf(series.seriesName)
-                            ]
+                            ],
+                            opacity: (scenario.name === chartData[0].name) ? 1.0 : 0.7
                           }
                         }}
                       />


### PR DESCRIPTION
When two scenarios are compared, they currently use the same colour sets. This proposed change adds a little transparency to the bars in the second scenario, allowing the eye to easily separate the main scenario and the comparator scenario.

I'm not sure that this is a good idea, but I think it helps.

This PR merges it into the energy-security branch, but I'm not sure where it's best placed.

Also, it's probably not the cleanest way to find out whether we're on the main scenario or the comparator scenario. If they've both got the same name, it will break. But if they've both got the same name, that's probably the least of our troubles.